### PR TITLE
Update xbox-remote-power.bat

### DIFF
--- a/xbox-remote-power.bat
+++ b/xbox-remote-power.bat
@@ -3,4 +3,6 @@ SETLOCAL
 SET IP_ADDR=0.0.0.0
 SET LIVE_ID=0000000000000000
 
+nslookup %IP_ADDR%
 python xbox-remote-power.py -a %IP_ADDR% -i %LIVE_ID%
+pause


### PR DESCRIPTION
Adds nslookup and a pause to provide the IP. This is helpful for people who have a dynamic IP address and are using a service like ddns. It allows people to skip looking up their ip afterwards.
