### PR TITLE
Simplified the py2/py3 blocks a bit

### DIFF
--- a/xbox-remote-power.py
+++ b/xbox-remote-power.py
@@ -36,10 +36,7 @@ def main():
 
     if ping:
         print("Attempting to ping Xbox for Live ID...")
-        if py3:
-            s.send(bytes.fromhex(XBOX_PING))
-        else:
-            s.send(XBOX_PING.decode("hex"))
+        s.send(bytearray.fromhex(XBOX_PING))
 
         ready = select.select([s], [], [], 5)
         if ready[0]:
@@ -52,20 +49,14 @@ def main():
     if isinstance(opts.live_id, str):
         live_id = opts.live_id.encode()
 
-    if py3:
-        power_packet = bytes.fromhex(XBOX_POWER)
-        power_packet = power_packet + live_id + b'\x00'    
-    else:
-        power_packet = XBOX_POWER + opts.live_id.encode("hex") + "00"
-        power_packet = power_packet.decode("hex")
-
+    power_packet = bytearray.fromhex(XBOX_POWER) + live_id + b'\x00'
     print("Sending power on packets to " + opts.ip_addr)
     for i in range(0, 5):
         s.send(power_packet)
         time.sleep(1)
     print("Xbox should turn on now")
 
-    s.send(bytes.fromhex(XBOX_PING))
+    s.send(bytearray.fromhex(XBOX_PING))
     ready = select.select([s], [], [], 5)
     if ready[0]:
         data = s.recv(1024)

--- a/xbox-remote-power.py
+++ b/xbox-remote-power.py
@@ -48,6 +48,8 @@ def main():
 
     if isinstance(opts.live_id, str):
         live_id = opts.live_id.encode()
+    else:
+        live_id = opts.live_id
 
     power_packet = bytearray.fromhex(XBOX_POWER) + live_id + b'\x00'
     print("Sending power on packets to " + opts.ip_addr)


### PR DESCRIPTION
Changed the blocks that did `decode("hex")` for py2 and `bytes.fromhex()` for py3 into a single `bytearray.fromhex()` line for each instance.

This should fix the issue #8 reported about AttributeError. 

I tested this on Python 2.7.10 and Python 3.5.0 with success turning the xbox on in both instances. The Xbox ping doesn't work for me unless the Xbox is already on, and for some reason the 2nd ping never works. I wonder if the socket needs to be re-opened fresh for it to work. Either way, the Xbox is being turned on, so at least it's working again :+1: 
